### PR TITLE
enable auto loader when clientHeight > postion

### DIFF
--- a/src/plugins/auto_pager.js
+++ b/src/plugins/auto_pager.js
@@ -1,7 +1,6 @@
 SF.pl.auto_pager = new SF.plugin((function($) {
 	var browse = 'http://fanfou.com/browse';
-	if (location.href.indexOf(browse) === 0)
-		return;
+	if (location.href.indexOf(browse) === 0) return;
 	var $more = $('#pagination-more');
 	if (! $more.length) return;
 
@@ -20,12 +19,9 @@ SF.pl.auto_pager = new SF.plugin((function($) {
 	var onScroll = SF.fn.throttle(autoPager, 250);
 
 	function autoPager() {
-		if (! mousewheel_down)
-			return;
+		if (! mousewheel_down) return;
 		current_pos = body.scrollTop + docelem.clientHeight;
 		if (current_pos <= $more.offset().top - remain)
-			return;
-		if (current_pos >= body.clientHeight)
 			return;
 		if ($more.hasClass('loading'))
 			return;


### PR DESCRIPTION
我更改了 自动加载更多的规则。

现在的做法是 页面拉到最低的时候， 不会触发 加载更多按钮，  造成很多时候加载更多的功能是无效的。

我删了这段代码，这样 加载到页底的时候也会出发加载更多按钮。
我觉得这样的体验更好一点。
