### PR TITLE
增加 version_name 支持

### DIFF
--- a/src/libs/getExtensionVersion.js
+++ b/src/libs/getExtensionVersion.js
@@ -1,1 +1,6 @@
-export default () => chrome.runtime.getManifest().version
+export default () => {
+  const {version, version_name} = chrome.runtime.getManifest()
+
+  // version_name 字段用于存放 beta 版本号，为空时表示正式版
+  return version_name || version
+}


### PR DESCRIPTION
### 使用方法

- 发布正式版时，保持 `version` 与 `version_name` 内容相同或者不再 `manifest.json` 文件中不包含 [version-name](https://developer.chrome.com/extensions/manifest/version) 字段
- 发布 beta 版时，设置 `version_name` 为 `{MAJOR}.{MINOR}.{PATCH}-beta.{VERSION}` 即可，例如 `1.0.0-beta.0`