### PR TITLE
修正开输入框不能看到源消息的问题

### DIFF
--- a/src/features/floating-status-form/script(page)[replay-and-repost].js
+++ b/src/features/floating-status-form/script(page)[replay-and-repost].js
@@ -38,6 +38,10 @@ export default context => {
     }
   }
 
+  function extractStatusId(li) {
+    return select('.stamp .time', li).getAttribute('ffid')
+  }
+
   function extractStatusContent(li) {
     // 不使用 select('.content', li).textContent.trim() 的方式
     // 因为 .content 的内容可能会被修改（比如展开短链接），也可能包含被截断的链接
@@ -84,8 +88,7 @@ export default context => {
     const { form, textarea } = elementCollection.getAll()
     const li = event.path.find(element => element.tagName.toLowerCase() === 'li')
     const authorElement = select('.author', li)
-    const contentElement = select('.content', li)
-    const targetStatusId = contentElement.getAttribute('id')
+    const targetStatusId = extractStatusId(li)
     const targetStatusAuthorNickname = '@' + authorElement.textContent
     const targetStatusText = extractStatusContent(li)
     const oldStatusContent = textarea.value.trim()


### PR DESCRIPTION
首页 Timeline 消息一般在 `span.content` 这个元素上会有一个 `id` 属性，即该条饭否消息的 id。之前浮动输入框插件在处理转发或回复按钮的点击操作时，会从这里读取消息 id。

```html
<li>
  <a href="/gravity0" title="gravity0" class="avatar">
    <img src="https://s3.meituan.net/v1/mss_3d027b52ec5a4d589e68050845611e68/avatar/s0/00/9f/d0.jpg?1245573453" alt="gravity0" />
  </a>
  <a href="/gravity0" class="author">gravity0</a>
  <span id="mjezsgBmIKU" class="content">TBBT 和 GoT 都在一个月后终结。室内剧的前者显然太长了。</span>
  <span class="stamp">
    <a href="/statuses/mjezsgBmIKU" class="time" title="2019-04-20 15:49" ffid="mjezsgBmIKU" stime="Sat Apr 20 07:49:50 +0000 2019">40 分钟前</a>
    <span class="method">通过网页</span>
  </span>
  <span class="op">
    <a href="/home?status=@gravity0+&in_reply_to_status_id=mjezsgBmIKU" ffname="gravity0" ffid="mjezsgBmIKU" class="reply" title="回复gravity0">回复gravity0</a>
    <a href="/favorite.add/mjezsgBmIKU" class="post_act share" title="添加到我的收藏" token="5c3e9c70">收藏</a>
    <a href="/home?status=%E8%BD%AC%40gravity0+TBBT+%E5%92%8C+GoT+%E9%83%BD%E5%9C%A8%E4%B8%80%E4%B8%AA%E6%9C%88%E5%90%8E%E7%BB%88%E7%BB%93%E3%80%82%E5%AE%A4%E5%86%85%E5%89%A7%E7%9A%84%E5%89%8D%E8%80%85%E6%98%BE%E7%84%B6%E5%A4%AA%E9%95%BF%E4%BA%86%E3%80%82&repost_status_id=mjezsgBmIKU" ffid="mjezsgBmIKU" text="转@gravity0 TBBT 和 GoT 都在一个月后终结。室内剧的前者显然太长了。" class="repost" title="转发">转发</a>
  </span>
</li>
```

但问题是，如果是展开转发或回复的消息，同样的位置没有这个 `id` 属性。这样一来转发或回复该消息时，相应的 `repost_status_id` 或 `in_reply_to_status_id` 字段就是空值。发布出来后会看不到源消息信息（如下图所示，看不到“转自gravity0”字样）。

![image](https://user-images.githubusercontent.com/1289884/56454902-7caf2300-638a-11e9-855d-c67b3266b55f.png)

改为从 `.stamp .time` 元素读取 `ffid` 这个 attribute，可以解决上述问题，因为无论一般 Timeline 消息还是展开的消息，这个属性都是存在的。