### PR TITLE
修正输入法输入内容未上屏时按 Esc 导致输入框失焦的问题

### DIFF
--- a/src/features/status-form-enhancements/script(page)[textarea-state].js
+++ b/src/features/status-form-enhancements/script(page)[textarea-state].js
@@ -24,7 +24,7 @@ export default context => {
   registerDOMEventListener('textarea', 'focus', onFocusedStateChanged)
   registerDOMEventListener('textarea', 'change', onChange)
   registerDOMEventListener('textarea', 'input', onChange)
-  registerDOMEventListener('textarea', 'keyup', onKeyUp)
+  registerDOMEventListener('textarea', 'keydown', onKeyDown)
   registerDOMEventListener('textarea', 'blur', onFocusedStateChanged)
 
   function onFocusedStateChanged() {
@@ -48,7 +48,7 @@ export default context => {
     counter.classList.toggle(CLASSNAME_EXCEEDED, hasExceeded)
   }
 
-  function onKeyUp(event) {
+  function onKeyDown(event) {
     const { textarea } = elementCollection.getAll()
 
     if (document.activeElement !== textarea) return


### PR DESCRIPTION
修正原理为，当输入法输入内容未上屏时按 <kbd>Esc</kbd> 键：

- 若监听 `mosueup` 事件，`event.key` 的值为 `"Escape"`
- 若监听 `mosuedown` 事件，`event.key` 的值为 `"Process"`

所以只要改为监听 `mousedown` 事件，`isHotkey(event, { key: 'Escape' })` 即得到 `false`，不再执行后面的语句。